### PR TITLE
Add support for int for serde_json::Value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,3 +16,4 @@ serde = "1.0"
 
 [dev-dependencies]
 serde_derive = "1.0"
+serde_json = "1.0"

--- a/src/de.rs
+++ b/src/de.rs
@@ -251,7 +251,6 @@ fn parse_number(pair: &Pair<'_, Rule>) -> f64 {
 }
 
 fn parse_integer(pair: &Pair<'_, Rule>) -> i64 {
-    println!("parse_integer {:}", pair.as_str());
     match pair.as_str() {
         s if is_hex_literal(s) => parse_hex(&s[2..]) as i64,
         s => s.parse().unwrap(),

--- a/src/de.rs
+++ b/src/de.rs
@@ -258,7 +258,8 @@ fn parse_integer(pair: &Pair<'_, Rule>) -> i64 {
 }
 
 fn is_int(s: &str) -> bool {
-    !s.contains('.')
+    !s.contains('.') &&
+        (is_hex_literal(s) || (!s.contains('e') && !s.contains('E')))
 }
 
 fn parse_hex(s: &str) -> u32 {

--- a/src/de.rs
+++ b/src/de.rs
@@ -51,7 +51,13 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut Deserializer<'de> {
             Rule::null => visitor.visit_unit(),
             Rule::boolean => visitor.visit_bool(parse_bool(&pair)),
             Rule::string | Rule::identifier => visitor.visit_string(parse_string(pair)),
-            Rule::number => visitor.visit_f64(parse_number(&pair)),
+            Rule::number => {
+                if is_int(pair.as_str()) {
+                    visitor.visit_i64(parse_integer(&pair))
+                } else {
+                    visitor.visit_f64(parse_number(&pair))
+                }
+            },
             Rule::array => visitor.visit_seq(Seq {
                 pairs: pair.into_inner(),
             }),
@@ -242,6 +248,18 @@ fn parse_number(pair: &Pair<'_, Rule>) -> f64 {
         s if is_hex_literal(s) => f64::from(parse_hex(&s[2..])),
         s => s.parse().unwrap(),
     }
+}
+
+fn parse_integer(pair: &Pair<'_, Rule>) -> i64 {
+    println!("parse_integer {:}", pair.as_str());
+    match pair.as_str() {
+        s if is_hex_literal(s) => parse_hex(&s[2..]) as i64,
+        s => s.parse().unwrap(),
+    }
+}
+
+fn is_int(s: &str) -> bool {
+    !s.contains('.')
 }
 
 fn parse_hex(s: &str) -> u32 {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -358,10 +358,15 @@ fn deserializes_ignored() {
 
 #[test]
 fn deserializes_json_values() {
-    // As int if json uses int type
+    // As int if json uses int type.
+    deserializes_to("0x2a", serde_json::json!(42));
     deserializes_to("0x2A", serde_json::json!(42));
+    deserializes_to("0X2A", serde_json::json!(42));
     deserializes_to("42", serde_json::json!(42));
 
-    // As float if json calls for explicit float type
+    // As float if json calls for explicit float type.
     deserializes_to("42.", serde_json::json!(42.));
+    deserializes_to("42e0", serde_json::json!(42.));
+    deserializes_to("4e2", serde_json::json!(400.));
+    deserializes_to("4e2", serde_json::json!(4e2));
 }

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -355,3 +355,13 @@ fn deserializes_ignored() {
 
     deserializes_to("{ a: 1, ignored: 42, b: 2 }", S { a: 1, b: 2 });
 }
+
+#[test]
+fn deserializes_json_values() {
+    // As int if json uses int type
+    deserializes_to("0x2A", serde_json::json!(42));
+    deserializes_to("42", serde_json::json!(42));
+
+    // As float if json calls for explicit float type
+    deserializes_to("42.", serde_json::json!(42.));
+}


### PR DESCRIPTION
When deserializing numbers into serde::Values, the numbers are always converted to floats. For example, 1 becomes 1.0