### PR TITLE
Expose Deserializer to other crates

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -23,14 +23,14 @@ where
     T::deserialize(&mut deserializer)
 }
 
-struct Deserializer<'de> {
+pub struct Deserializer<'de> {
     pair: Option<Pair<'de, Rule>>,
 }
 
 impl<'de> Deserializer<'de> {
     /// Creates a JSON5 deserializer from a `&str`. This parses the input at construction time, so
     /// can fail if the input is not valid JSON5.
-    fn from_str(input: &'de str) -> Result<Self> {
+    pub fn from_str(input: &'de str) -> Result<Self> {
         let pair = Parser::parse(Rule::text, input)?.next().unwrap();
         Ok(Deserializer::from_pair(pair))
     }


### PR DESCRIPTION
Hi,
I'm currently writing a crate which allows to interact with nested structures like you would with maps.
For getting values, some macro magic generates the appropriate getters, returning `&dyn Any`.
For inserting values, I need a key and a deserializer, which must `impl serde::Deserializer`. For json5 to be compatible with this use case (and I'd really like it to be), I need the deserializer to be exposed.
Thus this PR, hope you'll merge it at some point :)
Thanks,
Pierre.