### PR TITLE
Several performance improvements to serialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,10 @@ keywords = ["json5", "parse", "parser", "serde", "json"]
 edition = "2018"
 
 [dependencies]
+itoa = "1.0.1"
 pest = "2.0"
 pest_derive = "2.0"
+ryu = "1.0.9"
 serde = "1.0"
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 //! );
 //! assert_eq!(
 //!     json5::to_string(&Val::Object(map)),
-//!     Ok("{\"a\":[null,true,42,42.42,NaN,\"hello\"]}".to_owned()),
+//!     Ok("{\"a\":[null,true,42.0,42.42,NaN,\"hello\"]}".to_owned()),
 //! )
 //! ```
 //!
@@ -146,7 +146,7 @@
 //! );
 //! assert_eq!(
 //!     json5::to_string(&Value::Object(map)),
-//!     Ok("{\"a\":[null,true,42,42.42,\"hello\"]}".to_owned()),
+//!     Ok("{\"a\":[null,true,42.0,42.42,\"hello\"]}".to_owned()),
 //! )
 //! ```
 //!

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,7 +8,9 @@ pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: Serialize,
 {
-    let mut serializer = Serializer { output: Vec::new() };
+    let mut serializer = Serializer {
+        output: Vec::with_capacity(128),
+    };
     value.serialize(&mut serializer)?;
     Ok(String::from_utf8(serializer.output).expect("serialization emitted invalid UTF-8"))
 }

--- a/src/ser.rs
+++ b/src/ser.rs
@@ -8,11 +8,19 @@ pub fn to_string<T>(value: &T) -> Result<String>
 where
     T: Serialize,
 {
+    Ok(String::from_utf8(to_bytes(value)?).expect("serialization emitted invalid UTF-8"))
+}
+
+/// Attempts to serialize the input as a JSON5 byte sequence.
+pub fn to_bytes<T>(value: &T) -> Result<Vec<u8>>
+where
+    T: Serialize,
+{
     let mut serializer = Serializer {
         output: Vec::with_capacity(128),
     };
     value.serialize(&mut serializer)?;
-    Ok(String::from_utf8(serializer.output).expect("serialization emitted invalid UTF-8"))
+    Ok(serializer.output)
 }
 
 struct Serializer {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -148,7 +148,7 @@ fn serializes_newtype_struct() {
     struct B(f64);
 
     serializes_to(A(42), "42");
-    serializes_to(B(42.), "42");
+    serializes_to(B(42.), "42.0");
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn serializes_seq() {
             Val::Bool(true),
             Val::String("hello".to_owned()),
         ],
-        "[42,true,\"hello\"]",
+        "[42.0,true,\"hello\"]",
     )
 }
 
@@ -185,8 +185,8 @@ fn serializes_tuple_struct() {
     #[derive(Serialize, PartialEq, Debug)]
     struct B(f64, i32);
 
-    serializes_to(A(1, 2.), "[1,2]");
-    serializes_to(B(1., 2), "[1,2]");
+    serializes_to(A(1, 2.), "[1,2.0]");
+    serializes_to(B(1., 2), "[1.0,2]");
 }
 
 #[test]


### PR DESCRIPTION
- The `itoa` and `ryu` crates (the same crates `serde_json` uses) avoid allocating anything when serializing integers and floats.
- By switching the code to work on bytes instead of `&str`s, expensive Unicode handling can be avoided (e.g. `str::bytes` is a lot cheaper to run than `str::chars`).
- We can copy `serde_json` and start serialization with a capacity of 128, to avoid excessive reallocations.
- Since we use bytes now we might as well expose `ser::to_bytes`.