### PR TITLE
Remove Pest from the public API

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -31,7 +31,10 @@ impl<'de> Deserializer<'de> {
     /// Creates a JSON5 deserializer from a `&str`. This parses the input at construction time, so
     /// can fail if the input is not valid JSON5.
     pub fn from_str(input: &'de str) -> Result<Self> {
-        let pair = Parser::parse(Rule::text, input)?.next().unwrap();
+        let pair = Parser::parse(Rule::text, input)
+            .map_err(Error::from_pest)?
+            .next()
+            .unwrap();
         Ok(Deserializer::from_pair(pair))
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,13 +16,6 @@ pub struct Location {
     pub column: usize,
 }
 
-impl From<&Span<'_>> for Location {
-    fn from(s: &Span<'_>) -> Self {
-        let (line, column) = s.start_pos().line_col();
-        Self { line, column }
-    }
-}
-
 /// A bare bones error type which currently just collapses all the underlying errors in to a single
 /// string... This is fine for displaying to the user, but not very useful otherwise. Work to be
 /// done here.
@@ -37,8 +30,8 @@ pub enum Error {
     },
 }
 
-impl From<pest::error::Error<Rule>> for Error {
-    fn from(err: pest::error::Error<Rule>) -> Self {
+impl Error {
+    pub(crate) fn from_pest(err: pest::error::Error<Rule>) -> Self {
         let (line, column) = match err.line_col {
             pest::error::LineColLocation::Pos((l, c)) => (l, c),
             pest::error::LineColLocation::Span((l, c), (_, _)) => (l, c),
@@ -79,7 +72,7 @@ impl Display for Error {
 impl std::error::Error for Error {}
 
 /// Adds location information from `span`, if `res` is an error.
-pub fn set_location<T>(res: &mut Result<T>, span: &Span<'_>) {
+pub(crate) fn set_location<T>(res: &mut Result<T>, span: &Span<'_>) {
     if let Err(ref mut e) = res {
         let Error::Message { location, .. } = e;
         if location.is_none() {


### PR DESCRIPTION
This allows the library to upgrade to new version of Pest without making a breaking change to its own public API.