### PR TITLE
Support serializing bytes

### DIFF
--- a/src/ser.rs
+++ b/src/ser.rs
@@ -115,8 +115,8 @@ impl<'a> ser::Serializer for &'a mut Serializer {
         Ok(())
     }
 
-    fn serialize_bytes(self, _v: &[u8]) -> Result<()> {
-        unimplemented!() // TODO
+    fn serialize_bytes(self, v: &[u8]) -> Result<()> {
+        self.collect_seq(v)
     }
 
     fn serialize_none(self) -> Result<()> {

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -1,3 +1,4 @@
+use serde::{Serialize, Serializer};
 use serde_derive::Serialize;
 
 use std::collections::HashMap;
@@ -113,12 +114,19 @@ fn serializes_string() {
 }
 
 #[test]
-#[ignore] // TODO currently unsupported
-fn serializes_bytes() {}
-
-#[test]
-#[ignore] // TODO currently unsupported
-fn serializes_byte_buf() {}
+fn serializes_bytes() {
+    #[derive(Debug, PartialEq)]
+    struct Bytes<'a>(&'a [u8]);
+    impl Serialize for Bytes<'_> {
+        fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+            serializer.serialize_bytes(self.0)
+        }
+    }
+    serializes_to(Bytes(b""), "[]");
+    serializes_to(Bytes(b"a"), "[97]");
+    serializes_to(Bytes(&[0, 255]), "[0,255]");
+    serializes_to(Bytes(b"abc"), "[97,98,99]");
+}
 
 #[test]
 fn serializes_option() {


### PR DESCRIPTION
Implementing this is trivial, we can just serialize it as an array like `serde_json` does.