### PR TITLE
Simplified error message

### DIFF
--- a/tests/de.rs
+++ b/tests/de.rs
@@ -763,15 +763,9 @@ fn deserializes_json_values() {
 
 #[test]
 fn deserializes_parse_error() {
-    let parse_err_str = r#" --> 1:2
-  |
-1 | {
-  |  ^---
-  |
-  = expected identifier or string"#;
     #[derive(Deserialize, PartialEq, Debug)]
     struct A;
-    deserializes_with_error::<A>("{", make_error(parse_err_str, 1, 2));
+    deserializes_with_error::<A>("{", make_error("expected identifier or string", 1, 2));
 
     deserializes_with_error::<bool>(
         "\n 42",


### PR DESCRIPTION
I simplified an error message. Instead of something like this:
```
  --> 18:17
   |                     }
18 |                 ]␊
   |                 ^---
   |
   = expected array, boolean, null, number, object, or string
```
You'll get a more concise line: `expected array, boolean, null, number, object, or string`. This is useful for those who want to print their custom error messages and manually format an output. I think this behavior is more universal and convenient.